### PR TITLE
Pin nodejs to LTS 24 in docs environment

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,7 +10,8 @@ dependencies:
   - packaging
   - jupyter-packaging
   - jupyterlab >=4,<5
-  - nodejs >=18
+  # pin to LTS: nodejs 26+ cannot require() the yargs 16 pulled in by lerna 5
+  - nodejs 24.*
   # dependencies
   - jupyter_client
   # docs


### PR DESCRIPTION
Fixes the ReadTheDocs build failure in the `jlpm build` step.

With `nodejs >=18`, conda-forge now installs Node 26.5.0, and Node 26 cannot `require()` the extensionless `yargs/yargs` entry file from yargs 16, which lerna 5 depends on — Node 26's module-type detection classifies it as ESM, producing `ReferenceError: require is not defined in ES module scope`.

Verified against conda-forge Node builds with yargs 16.2.0 + lerna 5.6.2:

| Node | `require('yargs/yargs')` / lerna CLI |
|------|--------------------------------------|
| 22.22.2 | works |
| 24.18.0 | works |
| 26.5.0 | fails with the RTD traceback |

Pinning to `nodejs 24.*` (current LTS) resolves to 24.18.0, and the full `docs/environment.yml` still solves cleanly on conda-forge (python 3.14.6, sphinx 9.1, myst-nb 1.4).

Long-term fix is upgrading lerna (or otherwise getting yargs ≥18, which loads fine on Node 26); until then the pin carries a comment explaining why it exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148E6HYk5ARogwKjfHsKge8

---
_Generated by [Claude Code](https://claude.ai/code/session_0148E6HYk5ARogwKjfHsKge8)_