### PR TITLE
Pin Node to LTS 24 everywhere Node is provisioned

### DIFF
--- a/docs/source/dev_release.md
+++ b/docs/source/dev_release.md
@@ -9,7 +9,7 @@ conda deactivate
 conda remove --all -y -n releasewidgets
 rm -rf ipywidgets
 
-conda create -c conda-forge --override-channels -y -n releasewidgets notebook nodejs "yarn=3.*" twine jupyterlab=4 jupyter-packaging python-build jq "python==3.14.*"
+conda create -c conda-forge --override-channels -y -n releasewidgets notebook "nodejs=24.*" "yarn=3.*" twine jupyterlab=4 jupyter-packaging python-build jq "python==3.14.*"
 conda activate releasewidgets
 
 git clone git@github.com:jupyter-widgets/ipywidgets.git

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "typescript": "~4.9.4"
   },
   "engines": {
-    "node": ">=14",
+    "node": ">=18 <25",
     "npm": "please-use-yarn",
     "yarn": ">=3"
   }


### PR DESCRIPTION
Follow-up to the `docs/environment.yml` nodejs pin: Node 26 cannot `require()` the extensionless yargs 16 entry file that lerna 5 depends on, so every environment that runs `jlpm` needs Node <25.

This PR contains the two changes this session was able to push:

- **`docs/source/dev_release.md`**: pin `nodejs=24.*` in the release conda environment — it uses the same conda-forge channel that handed ReadTheDocs Node 26, so the next release would hit the identical lerna/yargs crash.
- **`package.json`**: tighten `engines.node` from `>=14` to `>=18 <25` — Yarn 3 enforces this, so anyone building locally on Node 26 gets an immediate clear error instead of the cryptic `require is not defined in ES module scope` crash.

**Missing piece (needs manual apply):** the same pin for CI. The credentials available to this session lack the `workflow` OAuth scope, so changes to `.github/workflows/*` could not be pushed. A patch adding `actions/setup-node@v6` with Node 24 to every job that runs `jlpm` (build, devinstall, lint, packaging, and the docs/js/spec/ui jobs in tests.yml) is attached in the session; apply it with `git am` onto this branch. Without it, CI keeps using whatever Node the GitHub runner image ships (currently ≤24, which is the only reason Actions stayed green while RTD broke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148E6HYk5ARogwKjfHsKge8

---
_Generated by [Claude Code](https://claude.ai/code/session_0148E6HYk5ARogwKjfHsKge8)_