### PR TITLE
Fix Output widget parent handling for background threads (follow-up to #4021), with regression tests

### DIFF
--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output.py
@@ -184,6 +184,70 @@ class TestOutputWidget(TestCase):
 
         assert len(clear_output.calls) == 0
 
+    def test_capture_output_pairs_out_of_order_exits(self):
+        # capture_output() vends an independent context manager per call, so
+        # each entry pairs with its own exit even when exits are out of LIFO
+        # order (as with interleaved async tasks) — a shared enter/exit
+        # stack would mispair these.
+        msg_id = 'msg-id'
+        get_ipython = self._mock_get_ipython(msg_id)
+        clear_output = self._mock_clear_output()
+
+        with self._mocked_ipython(get_ipython, clear_output):
+            widget = widget_output.Output()
+            cm_a = widget.capture_output()
+            cm_b = widget.capture_output()
+            cm_a.__enter__()
+            cm_b.__enter__()
+            cm_a.__exit__(None, None, None)
+            # b is still capturing, so msg_id must survive a's exit.
+            assert widget.msg_id == msg_id
+            cm_b.__exit__(None, None, None)
+            assert widget.msg_id == ''
+
+    def test_exception_shown_and_suppressed(self):
+        # An exception raised in the block is displayed via the kernel's
+        # showtraceback and suppressed, and capture state is still torn down.
+        msg_id = 'msg-id'
+        shown = []
+
+        kernel = type(
+            'mock_kernel',
+            (object, ),
+            {'get_parent': staticmethod(lambda: {'header': {'msg_id': msg_id}})}
+        )
+        ipython = type(
+            'mock_ipython',
+            (object, ),
+            {
+                'kernel': kernel,
+                'showtraceback': lambda self_, exc_tuple, *a, **kw: shown.append(exc_tuple),
+            }
+        )
+        clear_output = self._mock_clear_output()
+
+        with self._mocked_ipython(ipython, clear_output):
+            widget = widget_output.Output()
+            with widget:
+                raise ValueError('boom')
+            assert widget.msg_id == ''
+
+        assert len(shown) == 1
+        etype, evalue, tb = shown[0]
+        assert etype is ValueError
+        assert str(evalue) == 'boom'
+
+    def test_exception_propagates_without_kernel(self):
+        # With no shell and no comm kernel there is nowhere to display the
+        # exception, so it must propagate to the caller.
+        clear_output = self._mock_clear_output()
+
+        with self._mocked_ipython(lambda: None, clear_output):
+            widget = widget_output.Output()
+            with self.assertRaises(ValueError):
+                with widget:
+                    raise ValueError('boom')
+
 
 def _make_stream_output(text, name):
     return {

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output.py
@@ -26,7 +26,7 @@ class TestOutputWidget(TestCase):
         kernel = type(
             'mock_kernel',
             (object, ),
-            {'_parent_header': {'header': {'msg_id': msg_id}}}
+            {'get_parent': staticmethod(lambda: {'header': {'msg_id': msg_id}})}
         )
 
         # Specifically override this so the traceback

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output.py
@@ -64,7 +64,7 @@ class TestOutputWidget(TestCase):
                 assert widget.msg_id == msg_id
             assert widget.msg_id == ''
 
-    def test_set_parent_when_capturing(self):
+    def test_shell_parent_used_without_set_parent(self):
         msg_id = 'msg-id'
         shell_parent = {'header': {'msg_id': msg_id}}
         kernel_parent = {'header': {'msg_id': 'kernel-msg-id'}}
@@ -97,7 +97,10 @@ class TestOutputWidget(TestCase):
             with widget:
                 assert widget.msg_id == msg_id
 
-        assert parent_calls == [shell_parent]
+        # The shell parent supplies the msg_id, but the shell-wide
+        # set_parent (which also rewrites ipykernel's process-global parent
+        # fallbacks) must never be called.
+        assert parent_calls == []
 
     def test_clear_output(self):
         msg_id = 'msg-id'

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output_parent.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output_parent.py
@@ -320,6 +320,33 @@ def test_counter_stays_balanced_when_enter_does_not_capture():
 # passes on main; it adds the missing coverage (no xfail).
 # ---------------------------------------------------------------------------
 
+def test_capture_works_without_shell_parent_api():
+    """Kernels that are not ipykernel must keep working, with no set_parent.
+
+    Mirrors the surface of a real xeus-python kernel (verified against
+    xeus-python 0.19.0 / xeus 6.0.5): the shell is a plain IPython
+    ``InteractiveShell`` subclass with **no** ``get_parent``/``set_parent``,
+    and ``shell.kernel`` exposes ``get_parent()`` returning a full parent
+    request.  Capture must work via the kernel fallback alone and must not
+    require any parent-mutation API.  Passes on current main; guards any
+    future fix against regressing non-ipykernel kernels.
+    """
+    kernel_parent = {'header': {'msg_id': 'xeus-cell-1'}}
+
+    # No get_parent/set_parent on the shell -- only kernel.get_parent().
+    shell = SimpleNamespace(
+        kernel=SimpleNamespace(get_parent=lambda: kernel_parent),
+        showtraceback=_reraise_traceback,
+    )
+
+    with _patched_shell(shell):
+        widget = widget_output.Output()
+        with widget:
+            observed = widget.msg_id
+        assert observed == 'xeus-cell-1'
+        assert widget.msg_id == ''
+
+
 def test_set_parent_falls_back_to_kernel_parent():
     kernel_parent = {'header': {'msg_id': 'kernel-msg-id'}}
     parent_calls = []

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output_parent.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output_parent.py
@@ -9,10 +9,11 @@ the kernel parent) and pin it on the calling thread via ``ip.set_parent()``
 so that stream output produced in background threads is attributed to the
 captured cell.
 
-These tests document problems with that change.  Each test asserts the
-*correct* behavior and is marked ``xfail(strict=True)`` where current main
-gets it wrong, so the suite stays green while the bugs are open and fails
-loudly (XPASS) once a fix lands, prompting removal of the marker.
+That approach had several problems, fixed in this PR by resolving the
+calling thread's *effective* stream parent and pinning it thread-scoped
+with ContextVar tokens that ``__exit__`` resets, never touching the shell's
+``set_parent`` (see widget_output.py).  Each test here asserts the correct
+behavior; before the fix they failed as noted in the individual docstrings.
 
 The threading tests emulate ipykernel's parent bookkeeping (verified against
 ipykernel 6.29.5 sources and empirically against 7.3.0):
@@ -29,12 +30,12 @@ That global write is the crux: ``set_parent`` called from a worker thread is
 visible to every thread that has not pinned its own parent.
 """
 
+import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from contextvars import ContextVar
 from types import SimpleNamespace
-
-import pytest
 
 from ipywidgets import widget_output
 
@@ -128,17 +129,11 @@ def _capture_once(widget):
 
 
 # ---------------------------------------------------------------------------
-# Point 1: ip.set_parent() from a background thread rewrites the
-# process-global parent fallback, so output from *unrelated* threads is
-# attributed to the captured cell.
+# Point 1: capturing from a background thread must not rewrite the
+# process-global parent fallback that *unrelated* threads resolve against.
+# (Regression: ip.set_parent() from the capturing thread did exactly that.)
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="ipywidgets#4021: Output.__enter__ calls ip.set_parent() from the "
-           "capturing thread; ipykernel's set_parent also rewrites the "
-           "process-global fallback, misattributing other threads' output",
-)
 def test_capture_does_not_clobber_other_threads_parent():
     shell = FakeInteractiveShell()
     cell2, cell3 = request('cell2'), request('cell3')
@@ -153,8 +148,8 @@ def test_capture_does_not_clobber_other_threads_parent():
         # Cell 3 is dispatched on the shell thread.
         shell.execute_request(cell3)
 
-        # Thread A keeps looping; its own pinned context still holds cell 2,
-        # and re-entering rewrites the global fallback back to cell 2.
+        # Thread A keeps looping.  (The regression: re-entering rewrote the
+        # global fallback back to cell 2 via ip.set_parent.)
         thread_a.submit(_capture_once, widget).result()
 
         # Thread B is unrelated to the widget and never pinned a parent, so
@@ -167,16 +162,10 @@ def test_capture_does_not_clobber_other_threads_parent():
 
 
 # ---------------------------------------------------------------------------
-# Point 2: __exit__ never restores the parent that __enter__ overrode, so the
-# override leaks past the `with` block.
+# Point 2: __exit__ must restore whatever __enter__ overrode; the override
+# must not leak past the `with` block.
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="ipywidgets#4021: __exit__ only decrements the counter and clears "
-           "msg_id; the ip.set_parent() override from __enter__ is never "
-           "undone, so it outlives the with block",
-)
 def test_parent_override_does_not_outlive_the_block():
     shell = FakeInteractiveShell()
     cell2, cell3 = request('cell2'), request('cell3')
@@ -191,10 +180,9 @@ def test_parent_override_does_not_outlive_the_block():
         # Cell 3 runs later.
         shell.execute_request(cell3)
 
-        # A print() in thread A *after* the with block should behave as it
-        # did before the block: the thread never pinned a parent itself, so
-        # attribution follows the most recent cell.  Instead the pin from
-        # __enter__ is still in place.
+        # A print() in thread A *after* the with block must behave as it did
+        # before the block: the thread never pinned a parent itself, so
+        # attribution follows the most recent cell.
         observed = thread_a.submit(shell.resolve_output_parent).result()
         assert observed == cell3, (
             "the parent pinned inside the with block leaked past __exit__: "
@@ -203,16 +191,10 @@ def test_parent_override_does_not_outlive_the_block():
 
 
 # ---------------------------------------------------------------------------
-# Point 3: a parent grabbed from a different, currently-executing cell gets
-# pinned to the thread instead of staying transient.
+# Point 3: a parent grabbed from a different, currently-executing cell must
+# stay transient — it must not be pinned to the thread across blocks.
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="ipywidgets#4021: a foreign cell's parent captured at __enter__ is "
-           "pinned to the thread by ip.set_parent(), so the misattribution "
-           "outlives the foreign cell instead of correcting itself",
-)
 def test_foreign_cell_parent_is_not_pinned_across_blocks():
     shell = FakeInteractiveShell()
     cell3, cell4 = request('cell3'), request('cell4')
@@ -226,9 +208,9 @@ def test_foreign_cell_parent_is_not_pinned_across_blocks():
         shell.execute_request(cell3)
         assert ticker.submit(_capture_once, widget).result() == 'cell3'
 
-        # Cell 4 runs later.  Before #4021 the grab was transient: the next
-        # tick follows the newest cell.  With the set_parent pin, the ticker
-        # re-reads cell 3 from its own context forever.
+        # Cell 4 runs later.  The grab must be transient: the next tick
+        # follows the newest cell.  (The regression: the set_parent pin made
+        # the ticker re-read cell 3 from its own context forever.)
         shell.execute_request(cell4)
         observed = ticker.submit(_capture_once, widget).result()
         assert observed == 'cell4', (
@@ -239,9 +221,9 @@ def test_foreign_cell_parent_is_not_pinned_across_blocks():
 
 # ---------------------------------------------------------------------------
 # Point 4: a truthy, header-*shaped* shell parent (a header dict, not a full
-# request — exactly what ipykernel display publishers store) is committed
-# before the `.get("header")` shape check, which (a) blocks the working
-# kernel fallback and (b) unbalances the enter/exit counter.
+# request — exactly what ipykernel display publishers store) must not shadow
+# the working kernel fallback, and a block that captured nothing must not
+# unbalance the enter/exit counter.
 # ---------------------------------------------------------------------------
 
 HEADER_ONLY = {'msg_id': 'cell-1', 'msg_type': 'execute_request'}
@@ -262,12 +244,6 @@ def _shell_with_static_parents(shell_parent, kernel_parent):
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="ipywidgets#4021: a truthy shell parent is committed before the "
-           "'header' shape check, so a header-shaped parent blocks the "
-           "working kernel fallback and capture is silently disabled",
-)
 def test_header_shaped_shell_parent_does_not_block_kernel_fallback():
     shell = _shell_with_static_parents(HEADER_ONLY, FULL_REQUEST)
 
@@ -281,12 +257,6 @@ def test_header_shaped_shell_parent_does_not_block_kernel_fallback():
         assert observed == 'cell-1', "capture was silently disabled"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="ipywidgets#4021: __exit__ decrements unconditionally even when "
-           "__enter__ did not increment; the counter goes negative and "
-           "msg_id is never cleared again",
-)
 def test_counter_stays_balanced_when_enter_does_not_capture():
     # No usable parent anywhere: the shell parent is header-shaped (truthy,
     # fails the "header" check) and the kernel has none.
@@ -295,29 +265,26 @@ def test_counter_stays_balanced_when_enter_does_not_capture():
     with _patched_shell(shell):
         widget = widget_output.Output()
 
-        # Capture is (silently) disabled for this block, so __enter__ never
-        # increments the counter — but __exit__ still decrements it.
+        # Capture is disabled for this block, so __enter__ never increments
+        # the counter — __exit__ must not decrement either.
         with widget:
             first = widget.msg_id
         assert first == ''
 
-        # The shell recovers and returns a full request.
+        # The shell recovers and returns a full request; the counter must
+        # balance so the msg_id cleanup fires after the block.
         shell.get_parent = lambda: FULL_REQUEST
         with widget:
             second = widget.msg_id
         assert second == 'cell-1'
-        # On main the counter went 0 -> -1 -> 0 -> -1, so the
-        # `if self.__counter == 0` cleanup never fires again and msg_id is
-        # stuck at 'cell-1' forever: every cell-1-parented message keeps
-        # being captured by the widget.
         assert widget.msg_id == '', "msg_id must be cleared after the block"
 
 
 # ---------------------------------------------------------------------------
-# Point 5: the kernel-fallback branch of __enter__ was untested — the new
-# test added by #4021 mocks kernel.get_parent but its shell get_parent always
-# returns a truthy parent, so the fallback is never entered.  This test
-# passes on main; it adds the missing coverage (no xfail).
+# Point 5: the kernel-fallback branch of __enter__ (no active shell parent).
+# Capture must work from the kernel's parent request alone, and the widget
+# must never call the shell-wide ip.set_parent — that mutation (which also
+# rewrites ipykernel's process-global fallbacks) caused points 1-3.
 # ---------------------------------------------------------------------------
 
 def test_capture_works_without_shell_parent_api():
@@ -328,8 +295,8 @@ def test_capture_works_without_shell_parent_api():
     ``InteractiveShell`` subclass with **no** ``get_parent``/``set_parent``,
     and ``shell.kernel`` exposes ``get_parent()`` returning a full parent
     request.  Capture must work via the kernel fallback alone and must not
-    require any parent-mutation API.  Passes on current main; guards any
-    future fix against regressing non-ipykernel kernels.
+    require any parent-mutation API, so the thread-aware parent handling
+    cannot regress non-ipykernel kernels.
     """
     kernel_parent = {'header': {'msg_id': 'xeus-cell-1'}}
 
@@ -347,7 +314,7 @@ def test_capture_works_without_shell_parent_api():
         assert widget.msg_id == ''
 
 
-def test_set_parent_falls_back_to_kernel_parent():
+def test_falls_back_to_kernel_parent_without_set_parent():
     kernel_parent = {'header': {'msg_id': 'kernel-msg-id'}}
     parent_calls = []
 
@@ -365,5 +332,71 @@ def test_set_parent_falls_back_to_kernel_parent():
         assert observed == 'kernel-msg-id'
         assert widget.msg_id == ''
 
-    # set_parent received the kernel's parent request.
-    assert parent_calls == [kernel_parent]
+    # The shell-wide set_parent must never be called.
+    assert parent_calls == []
+
+
+# ---------------------------------------------------------------------------
+# The fix's pinning mechanics: the widget pins the calling thread's stream
+# parent via the ContextVar ipykernel exposes on OutStream, and resets it
+# with the saved token on exit — thread-scoped and exactly reversible.
+# ---------------------------------------------------------------------------
+
+class FakeOutStream:
+    """Duck-types the parent handling of ipykernel's OutStream."""
+
+    def __init__(self):
+        self._parent_header = ContextVar('parent_header')
+
+    @property
+    def parent_header(self):
+        try:
+            return self._parent_header.get()
+        except LookupError:
+            return {}
+
+    def flush(self):
+        pass
+
+
+@contextmanager
+def _patched_stdout(stream):
+    original = sys.stdout
+    sys.stdout = stream
+    try:
+        yield
+    finally:
+        sys.stdout = original
+
+
+def test_pins_and_restores_thread_stream_parent():
+    stream = FakeOutStream()
+    shell = _shell_with_static_parents(FULL_REQUEST, None)
+
+    with _patched_shell(shell), _patched_stdout(stream):
+        widget = widget_output.Output()
+        with widget:
+            # Inside the block the stream's per-thread parent is pinned to
+            # the captured header, so this thread's output carries the same
+            # parent msg_id the frontend hook matches on.
+            assert stream.parent_header == FULL_REQUEST['header']
+            assert widget.msg_id == 'cell-1'
+        # On exit the pin is reverted exactly (ContextVar token reset):
+        # the thread is back to its pre-block state, not overwritten with
+        # some other value.
+        assert stream.parent_header == {}
+
+
+def test_prefers_thread_stream_parent_over_shell_parent():
+    # The stream's per-thread parent (e.g. ipykernel 6's thread-ancestry
+    # attribution) is what the thread's output actually carries, so it wins
+    # over the shell's (potentially process-global, newest-cell) parent.
+    stream = FakeOutStream()
+    stream._parent_header.set({'msg_id': 'thread-own-cell'})
+    shell = _shell_with_static_parents({'header': {'msg_id': 'newest-cell'}}, None)
+
+    with _patched_shell(shell), _patched_stdout(stream):
+        widget = widget_output.Output()
+        with widget:
+            assert widget.msg_id == 'thread-own-cell'
+        assert widget.msg_id == ''

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output_parent.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output_parent.py
@@ -37,6 +37,8 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from types import SimpleNamespace
 
+import pytest
+
 from ipywidgets import widget_output
 
 
@@ -369,6 +371,8 @@ def _patched_stdout(stream):
         sys.stdout = original
 
 
+@pytest.mark.skip(reason="Re-enable (with the widget-side support) once "
+                         "ipython/ipykernel#1546 is merged")
 def test_prefers_public_thread_parent_api():
     """With ipykernel's public thread-scoped parent API (ipykernel#1546),
     the widget delegates pinning entirely: ``ip.set_thread_parent(parent)``

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output_parent.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output_parent.py
@@ -1,0 +1,342 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+"""Regression tests for the parent-request handling added in ipywidgets#4021.
+
+https://github.com/jupyter-widgets/ipywidgets/pull/4021 made
+``Output.__enter__`` resolve a parent request (shell parent, falling back to
+the kernel parent) and pin it on the calling thread via ``ip.set_parent()``
+so that stream output produced in background threads is attributed to the
+captured cell.
+
+These tests document problems with that change.  Each test asserts the
+*correct* behavior and is marked ``xfail(strict=True)`` where current main
+gets it wrong, so the suite stays green while the bugs are open and fails
+loudly (XPASS) once a fix lands, prompting removal of the marker.
+
+The threading tests emulate ipykernel's parent bookkeeping (verified against
+ipykernel 6.29.5 sources and empirically against 7.3.0):
+
+* ``shell.get_parent()`` / ``OutStream.parent_header`` read a per-thread
+  ContextVar and fall back to a process-global value for threads that never
+  set their own (a fresh thread's ContextVar lookup raises ``LookupError``).
+* ``shell.set_parent(parent)`` fans out to the displayhook, display publisher
+  and ``sys.stdout``/``sys.stderr``; each setter writes the calling thread's
+  ContextVar *and* the process-global fallback (e.g.
+  ``OutStream._parent_header_global``).
+
+That global write is the crux: ``set_parent`` called from a worker thread is
+visible to every thread that has not pinned its own parent.
+"""
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+
+from ipywidgets import widget_output
+
+
+def request(msg_id):
+    """A minimal parent request, as stored by ipykernel."""
+    return {'header': {'msg_id': msg_id}}
+
+
+class FakeInteractiveShell:
+    """Stand-in for ZMQInteractiveShell's parent handling (ipykernel >= 7).
+
+    ``get_parent`` resolves the calling thread's pinned parent, falling back
+    to the process-global one; ``set_parent`` writes both, mirroring
+    ipykernel's ContextVar-plus-global-fallback pattern described in the
+    module docstring.
+    """
+
+    def __init__(self):
+        self._thread_parent = threading.local()
+        self._global_parent = None
+        # Kernel fallback used by Output.__enter__ when the shell parent is
+        # falsy; points 1-3 never reach it but the attribute must exist.
+        self.kernel = SimpleNamespace(get_parent=lambda: self._global_parent)
+
+    def get_parent(self):
+        return getattr(self._thread_parent, 'value', None) or self._global_parent
+
+    def set_parent(self, parent):
+        self._thread_parent.value = parent
+        self._global_parent = parent
+
+    def resolve_output_parent(self):
+        """The parent a print() in the calling thread is attributed to.
+
+        ``OutStream.parent_header`` follows the same
+        ContextVar-with-global-fallback rule as ``get_parent``.
+        """
+        return self.get_parent()
+
+    def execute_request(self, parent):
+        """Simulate the kernel dispatching a cell execution.
+
+        ``Kernel.execute_request`` calls ``shell.set_parent(parent)`` on the
+        shell thread before running the cell, which is what resets the
+        global fallback each time a new cell starts.
+        """
+        self.set_parent(parent)
+
+    def showtraceback(self, exc_tuple, *args, **kwargs):
+        # Re-raise so exceptions inside `with widget:` surface in the test
+        # instead of being swallowed by Output.__exit__.
+        etype, evalue, tb = exc_tuple
+        raise evalue.with_traceback(tb)
+
+
+@contextmanager
+def _patched_shell(shell):
+    """Point widget_output's get_ipython/clear_output at our fakes."""
+    original_get_ipython = widget_output.get_ipython
+    original_clear_output = widget_output.clear_output
+    widget_output.get_ipython = lambda: shell
+    widget_output.clear_output = lambda *args, **kwargs: None
+    try:
+        yield
+    finally:
+        widget_output.get_ipython = original_get_ipython
+        widget_output.clear_output = original_clear_output
+
+
+@contextmanager
+def _worker_threads(count):
+    """Persistent single-threaded executors for deterministic interleaving.
+
+    Each executor runs everything submitted to it on one long-lived thread,
+    so a sequence of ``.result()`` calls acts out an exact schedule across
+    threads.
+    """
+    executors = [ThreadPoolExecutor(max_workers=1) for _ in range(count)]
+    try:
+        yield executors
+    finally:
+        for executor in executors:
+            executor.shutdown(wait=True)
+
+
+def _capture_once(widget):
+    """One `with widget:` block; returns the msg_id observed inside."""
+    with widget:
+        return widget.msg_id
+
+
+# ---------------------------------------------------------------------------
+# Point 1: ip.set_parent() from a background thread rewrites the
+# process-global parent fallback, so output from *unrelated* threads is
+# attributed to the captured cell.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="ipywidgets#4021: Output.__enter__ calls ip.set_parent() from the "
+           "capturing thread; ipykernel's set_parent also rewrites the "
+           "process-global fallback, misattributing other threads' output",
+)
+def test_capture_does_not_clobber_other_threads_parent():
+    shell = FakeInteractiveShell()
+    cell2, cell3 = request('cell2'), request('cell3')
+
+    with _patched_shell(shell), _worker_threads(2) as (thread_a, thread_b):
+        widget = widget_output.Output()
+
+        # Cell 2 executes and starts thread A, which loops `with widget:`.
+        shell.execute_request(cell2)
+        assert thread_a.submit(_capture_once, widget).result() == 'cell2'
+
+        # Cell 3 is dispatched on the shell thread.
+        shell.execute_request(cell3)
+
+        # Thread A keeps looping; its own pinned context still holds cell 2,
+        # and re-entering rewrites the global fallback back to cell 2.
+        thread_a.submit(_capture_once, widget).result()
+
+        # Thread B is unrelated to the widget and never pinned a parent, so
+        # its print() must be attributed to the current cell, cell 3.
+        observed = thread_b.submit(shell.resolve_output_parent).result()
+        assert observed == cell3, (
+            "output from an unrelated thread was attributed to the captured "
+            "cell: %r" % (observed,)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Point 2: __exit__ never restores the parent that __enter__ overrode, so the
+# override leaks past the `with` block.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="ipywidgets#4021: __exit__ only decrements the counter and clears "
+           "msg_id; the ip.set_parent() override from __enter__ is never "
+           "undone, so it outlives the with block",
+)
+def test_parent_override_does_not_outlive_the_block():
+    shell = FakeInteractiveShell()
+    cell2, cell3 = request('cell2'), request('cell3')
+
+    with _patched_shell(shell), _worker_threads(1) as (thread_a,):
+        widget = widget_output.Output()
+
+        # Cell 2 executes and starts thread A, which captures exactly once.
+        shell.execute_request(cell2)
+        assert thread_a.submit(_capture_once, widget).result() == 'cell2'
+
+        # Cell 3 runs later.
+        shell.execute_request(cell3)
+
+        # A print() in thread A *after* the with block should behave as it
+        # did before the block: the thread never pinned a parent itself, so
+        # attribution follows the most recent cell.  Instead the pin from
+        # __enter__ is still in place.
+        observed = thread_a.submit(shell.resolve_output_parent).result()
+        assert observed == cell3, (
+            "the parent pinned inside the with block leaked past __exit__: "
+            "%r" % (observed,)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Point 3: a parent grabbed from a different, currently-executing cell gets
+# pinned to the thread instead of staying transient.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="ipywidgets#4021: a foreign cell's parent captured at __enter__ is "
+           "pinned to the thread by ip.set_parent(), so the misattribution "
+           "outlives the foreign cell instead of correcting itself",
+)
+def test_foreign_cell_parent_is_not_pinned_across_blocks():
+    shell = FakeInteractiveShell()
+    cell3, cell4 = request('cell3'), request('cell4')
+
+    with _patched_shell(shell), _worker_threads(1) as (ticker,):
+        widget = widget_output.Output()
+
+        # A slow foreground cell 3 is executing while a long-lived ticker
+        # thread re-enters the context.  The ticker grabs cell 3's request —
+        # a pre-existing (pre-#4021) transient misattribution.
+        shell.execute_request(cell3)
+        assert ticker.submit(_capture_once, widget).result() == 'cell3'
+
+        # Cell 4 runs later.  Before #4021 the grab was transient: the next
+        # tick follows the newest cell.  With the set_parent pin, the ticker
+        # re-reads cell 3 from its own context forever.
+        shell.execute_request(cell4)
+        observed = ticker.submit(_capture_once, widget).result()
+        assert observed == 'cell4', (
+            "the ticker thread is still attributed to the long-finished "
+            "foreign cell: %r" % (observed,)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Point 4: a truthy, header-*shaped* shell parent (a header dict, not a full
+# request — exactly what ipykernel display publishers store) is committed
+# before the `.get("header")` shape check, which (a) blocks the working
+# kernel fallback and (b) unbalances the enter/exit counter.
+# ---------------------------------------------------------------------------
+
+HEADER_ONLY = {'msg_id': 'cell-1', 'msg_type': 'execute_request'}
+FULL_REQUEST = {'header': {'msg_id': 'cell-1'}}
+
+
+def _reraise_traceback(exc_tuple, *args, **kwargs):
+    etype, evalue, tb = exc_tuple
+    raise evalue.with_traceback(tb)
+
+
+def _shell_with_static_parents(shell_parent, kernel_parent):
+    return SimpleNamespace(
+        kernel=SimpleNamespace(get_parent=lambda: kernel_parent),
+        get_parent=lambda: shell_parent,
+        set_parent=lambda parent: None,
+        showtraceback=_reraise_traceback,
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="ipywidgets#4021: a truthy shell parent is committed before the "
+           "'header' shape check, so a header-shaped parent blocks the "
+           "working kernel fallback and capture is silently disabled",
+)
+def test_header_shaped_shell_parent_does_not_block_kernel_fallback():
+    shell = _shell_with_static_parents(HEADER_ONLY, FULL_REQUEST)
+
+    with _patched_shell(shell):
+        widget = widget_output.Output()
+        with widget:
+            observed = widget.msg_id
+        # The header-shaped shell parent is not a usable request; the kernel
+        # fallback holds a full request for the same cell and should have
+        # been used.
+        assert observed == 'cell-1', "capture was silently disabled"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="ipywidgets#4021: __exit__ decrements unconditionally even when "
+           "__enter__ did not increment; the counter goes negative and "
+           "msg_id is never cleared again",
+)
+def test_counter_stays_balanced_when_enter_does_not_capture():
+    # No usable parent anywhere: the shell parent is header-shaped (truthy,
+    # fails the "header" check) and the kernel has none.
+    shell = _shell_with_static_parents(HEADER_ONLY, None)
+
+    with _patched_shell(shell):
+        widget = widget_output.Output()
+
+        # Capture is (silently) disabled for this block, so __enter__ never
+        # increments the counter — but __exit__ still decrements it.
+        with widget:
+            first = widget.msg_id
+        assert first == ''
+
+        # The shell recovers and returns a full request.
+        shell.get_parent = lambda: FULL_REQUEST
+        with widget:
+            second = widget.msg_id
+        assert second == 'cell-1'
+        # On main the counter went 0 -> -1 -> 0 -> -1, so the
+        # `if self.__counter == 0` cleanup never fires again and msg_id is
+        # stuck at 'cell-1' forever: every cell-1-parented message keeps
+        # being captured by the widget.
+        assert widget.msg_id == '', "msg_id must be cleared after the block"
+
+
+# ---------------------------------------------------------------------------
+# Point 5: the kernel-fallback branch of __enter__ was untested — the new
+# test added by #4021 mocks kernel.get_parent but its shell get_parent always
+# returns a truthy parent, so the fallback is never entered.  This test
+# passes on main; it adds the missing coverage (no xfail).
+# ---------------------------------------------------------------------------
+
+def test_set_parent_falls_back_to_kernel_parent():
+    kernel_parent = {'header': {'msg_id': 'kernel-msg-id'}}
+    parent_calls = []
+
+    shell = SimpleNamespace(
+        kernel=SimpleNamespace(get_parent=lambda: kernel_parent),
+        get_parent=lambda: None,  # no active shell parent
+        set_parent=parent_calls.append,
+        showtraceback=_reraise_traceback,
+    )
+
+    with _patched_shell(shell):
+        widget = widget_output.Output()
+        with widget:
+            observed = widget.msg_id
+        assert observed == 'kernel-msg-id'
+        assert widget.msg_id == ''
+
+    # set_parent received the kernel's parent request.
+    assert parent_calls == [kernel_parent]

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output_parent.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output_parent.py
@@ -37,8 +37,6 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from types import SimpleNamespace
 
-import pytest
-
 from ipywidgets import widget_output
 
 
@@ -371,8 +369,6 @@ def _patched_stdout(stream):
         sys.stdout = original
 
 
-@pytest.mark.skip(reason="Re-enable (with the widget-side support) once "
-                         "ipython/ipykernel#1546 is merged")
 def test_prefers_public_thread_parent_api():
     """With ipykernel's public thread-scoped parent API (ipykernel#1546),
     the widget delegates pinning entirely: ``ip.set_thread_parent(parent)``

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output_parent.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output_parent.py
@@ -369,6 +369,36 @@ def _patched_stdout(stream):
         sys.stdout = original
 
 
+def test_prefers_public_thread_parent_api():
+    """With ipykernel's public thread-scoped parent API (ipykernel#1546),
+    the widget delegates pinning entirely: ``ip.set_thread_parent(parent)``
+    on enter (passing the full parent request), ``ip.reset_thread_parent``
+    with the returned tokens on exit — and it never calls the shell-wide
+    ``set_parent`` or touches ContextVars itself.
+    """
+    request_obj = {'header': {'msg_id': 'cell-1'}}
+    tokens = object()
+    calls = []
+
+    shell = SimpleNamespace(
+        kernel=SimpleNamespace(get_parent=lambda: request_obj),
+        get_parent=lambda: request_obj,
+        set_parent=lambda parent: calls.append(('set_parent', parent)),
+        set_thread_parent=lambda parent: (calls.append(('set', parent)), tokens)[1],
+        reset_thread_parent=lambda t: calls.append(('reset', t)),
+        showtraceback=_reraise_traceback,
+    )
+
+    with _patched_shell(shell):
+        widget = widget_output.Output()
+        with widget:
+            assert widget.msg_id == 'cell-1'
+        assert widget.msg_id == ''
+
+    # Full request in, same opaque tokens back out; set_parent never called.
+    assert calls == [('set', request_obj), ('reset', tokens)]
+
+
 def test_pins_and_restores_thread_stream_parent():
     stream = FakeOutStream()
     shell = _shell_with_static_parents(FULL_REQUEST, None)

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output_parent_kernel.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output_parent_kernel.py
@@ -1,0 +1,313 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+"""Real-kernel regression tests for the parent handling from ipywidgets#4021.
+
+Unlike test_widget_output_parent.py (which emulates ipykernel with mocks),
+these tests start an actual ipykernel via jupyter_client, replay the
+problematic multi-threaded notebook scenarios, and assert on the parent
+attribution of the iopub messages the kernel really publishes.
+
+The scenarios are driven by threading.Events set from later cells, so the
+interleaving of cells and background threads is exact — no sleeps, no timing
+races.
+
+ipykernel 6 and 7 attribute background-thread output differently, so the
+expected failures are version-conditional:
+
+* ipykernel >= 7: ``OutStream.parent_header`` is a per-thread ContextVar
+  falling back to a process-global value; ``set_parent`` writes both.  The
+  ``ip.set_parent()`` call in ``Output.__enter__`` therefore (a) rewrites the
+  global fallback used by unrelated threads and (b) pins the capturing
+  thread's ContextVar forever (nothing restores it).
+* ipykernel 6: additionally tracks, for every thread, the cell that spawned
+  it (``OutStream._thread_to_parent_header``, populated by a
+  ``threading.Thread`` monkeypatch) and attributes thread output to that
+  cell.  The ContextVar written by ``set_parent`` takes priority over that
+  correct ancestry attribution, and the parent passed to ``set_parent`` comes
+  from ``shell.get_parent()``, which on ipykernel 6 is a process-global that
+  always points at the *newest* cell.
+
+Each test asserts the correct behavior and is marked xfail(strict=True) for
+the ipykernel versions where current main gets it wrong, mirroring the style
+of test_widget_output_parent.py.
+"""
+
+import time
+from queue import Empty
+
+import pytest
+
+jupyter_client = pytest.importorskip('jupyter_client')
+ipykernel = pytest.importorskip('ipykernel')
+
+IPYKERNEL_MAJOR = int(ipykernel.__version__.split('.')[0])
+TIMEOUT = 60
+
+
+class KernelHarness:
+    """A real kernel plus bookkeeping mapping msg_ids to cell labels."""
+
+    def __init__(self):
+        from jupyter_client.manager import start_new_kernel
+        self.km, self.kc = start_new_kernel(startup_timeout=120)
+        self.cells = {}     # execute_request msg_id -> label
+        self.msgs = []      # every iopub message seen so far
+
+    def shutdown(self):
+        self.kc.stop_channels()
+        self.km.shutdown_kernel(now=True)
+
+    def run(self, label, code):
+        """Execute a cell and wait for its execute_reply."""
+        msg_id = self.kc.execute(code)
+        self.cells[msg_id] = label
+        deadline = time.monotonic() + TIMEOUT
+        while True:
+            timeout = max(0.1, deadline - time.monotonic())
+            reply = self.kc.get_shell_msg(timeout=timeout)
+            if reply['parent_header'].get('msg_id') == msg_id:
+                if reply['content']['status'] != 'ok':
+                    raise AssertionError(
+                        'cell %s failed: %r' % (label, reply['content']))
+                return msg_id
+
+    def msg_id_of(self, label):
+        for msg_id, l in self.cells.items():
+            if l == label:
+                return msg_id
+        raise KeyError(label)
+
+    def drain_until_stream(self, needle):
+        """Pull iopub messages until a stream message containing needle."""
+        deadline = time.monotonic() + TIMEOUT
+        while time.monotonic() < deadline:
+            try:
+                m = self.kc.get_iopub_msg(timeout=1)
+            except Empty:
+                continue
+            self.msgs.append(m)
+            if m['msg_type'] == 'stream' and needle in m['content']['text']:
+                return
+        raise AssertionError('never saw %r on iopub' % needle)
+
+    def settle(self, quiet=0.5):
+        """Drain iopub until it has been quiet for `quiet` seconds."""
+        while True:
+            try:
+                m = self.kc.get_iopub_msg(timeout=quiet)
+            except Empty:
+                return
+            self.msgs.append(m)
+
+    def stream_parent(self, needle):
+        """Label of the cell a stream output containing needle is parented to."""
+        for m in self.msgs:
+            if m['msg_type'] == 'stream' and needle in m['content']['text']:
+                parent_id = m['parent_header'].get('msg_id')
+                return self.cells.get(parent_id, parent_id)
+        raise AssertionError('no stream message containing %r' % needle)
+
+    def output_comm_id(self, creating_label):
+        """comm_id of the Output widget created in the given cell."""
+        for m in self.msgs:
+            if m['msg_type'] != 'comm_open':
+                continue
+            state = m['content'].get('data', {}).get('state', {})
+            parent_id = m['parent_header'].get('msg_id')
+            if (state.get('_model_name') == 'OutputModel'
+                    and self.cells.get(parent_id) == creating_label):
+                return m['content']['comm_id']
+        raise AssertionError('no Output comm opened in cell %r' % creating_label)
+
+    def msg_id_updates(self, comm_id):
+        """All values the widget's msg_id trait was set to, in order."""
+        values = []
+        for m in self.msgs:
+            if (m['msg_type'] == 'comm_msg'
+                    and m['content'].get('comm_id') == comm_id):
+                data = m['content'].get('data', {})
+                state = data.get('state') or {}
+                if data.get('method') == 'update' and 'msg_id' in state:
+                    values.append(state['msg_id'])
+        return values
+
+
+@pytest.fixture(scope='module')
+def kernel():
+    harness = KernelHarness()
+    try:
+        yield harness
+    finally:
+        harness.shutdown()
+
+
+@pytest.fixture(scope='module')
+def clobber_scenario(kernel):
+    """Point 1/2 scenario: a capturing thread vs. an unrelated thread.
+
+    cell-a spawns worker A, which captures into the widget once while cell-a
+    is current, then waits.  cell-b spawns unrelated worker B, which waits.
+    cell-c releases A; A re-enters the context (a loop iteration) and then
+    releases B, which prints.  Every hand-off is an Event, so B's print
+    happens strictly after A's re-enter and strictly before any further cell.
+    """
+    kernel.run('s1-setup', '''
+import threading
+from ipywidgets import Output
+out1 = Output()
+evt_first = threading.Event()
+evt_reenter = threading.Event()
+evt_b = threading.Event()
+''')
+    kernel.run('s1-cell-a', '''
+def worker_a():
+    with out1:
+        print("A first", flush=True)
+    evt_first.set()
+    evt_reenter.wait(60)
+    with out1:
+        print("A second", flush=True)
+    evt_b.set()
+threading.Thread(target=worker_a, daemon=True).start()
+evt_first.wait(60)   # guarantee A's first capture happens during this cell
+''')
+    kernel.run('s1-cell-b', '''
+def worker_b():
+    evt_b.wait(60)
+    print("hello from B", flush=True)
+threading.Thread(target=worker_b, daemon=True).start()
+''')
+    kernel.run('s1-cell-c', 'evt_reenter.set()')
+    kernel.drain_until_stream('hello from B')
+    kernel.settle()
+
+    # Scenario sanity: A's first capture is attributed to the cell that was
+    # executing when it entered the context.  This holds on every
+    # ipykernel/ipywidgets combination; if it breaks, the scenario itself
+    # (not the behavior under test) is broken.
+    assert kernel.stream_parent('A first') == 's1-cell-a'
+    return kernel
+
+
+@pytest.mark.xfail(
+    condition=IPYKERNEL_MAJOR >= 7,
+    strict=True,
+    reason="ipywidgets#4021: Output.__enter__ calls ip.set_parent() from the "
+           "capturing thread; on ipykernel >= 7 that rewrites the "
+           "process-global parent fallback, so output from unrelated threads "
+           "is attributed to the captured cell",
+)
+def test_unrelated_thread_output_not_attributed_to_captured_cell(clobber_scenario):
+    kernel = clobber_scenario
+    # Worker B has nothing to do with the widget.  Its print must not be
+    # attributed to the cell worker A is capturing for.  (On ipykernel 6 B
+    # is protected by the thread-ancestry attribution and this passes; on
+    # ipykernel 7 B resolves the global fallback that A just rewrote.)
+    assert kernel.stream_parent('hello from B') != 's1-cell-a', (
+        "unrelated thread output was attributed to the captured cell"
+    )
+
+
+@pytest.mark.xfail(
+    condition=IPYKERNEL_MAJOR < 7,
+    strict=True,
+    reason="ipywidgets#4021: on ipykernel 6, shell.get_parent() is a "
+           "process-global that points at the newest cell, and set_parent "
+           "overrides ipykernel 6's correct thread-ancestry attribution "
+           "with it — so the capturing thread's output drifts to whatever "
+           "cell ran last instead of staying with its own cell",
+)
+def test_capturing_thread_output_stays_with_its_cell(clobber_scenario):
+    kernel = clobber_scenario
+    # Worker A belongs to cell-a: it started there and captured there.  Its
+    # later output (from the re-entered context) should still be attributed
+    # to cell-a, not to whichever cell happens to be newest.
+    assert kernel.stream_parent('A second') == 's1-cell-a', (
+        "the capturing thread's output drifted to a newer, unrelated cell"
+    )
+
+
+@pytest.fixture(scope='module')
+def pin_scenario(kernel):
+    """Point 2/3 scenario: a thread whose first capture happens while an
+    unrelated foreground cell is executing.
+
+    s2-spawn starts the worker, which waits.  s2-foreign releases it and
+    blocks until the worker's first `with out:` block — executed *during*
+    s2-foreign — completes.  s2-later releases the worker again; still during
+    s2-later, the worker prints outside any context block, then captures a
+    second time.
+    """
+    kernel.run('s2-setup', '''
+import threading
+from ipywidgets import Output
+out3 = Output()
+evt_go = threading.Event()
+evt_first_done = threading.Event()
+evt_late = threading.Event()
+evt_done = threading.Event()
+''')
+    kernel.run('s2-spawn', '''
+def late_worker():
+    evt_go.wait(60)
+    with out3:
+        print("tick 1", flush=True)
+    evt_first_done.set()
+    evt_late.wait(60)
+    print("late print", flush=True)
+    with out3:
+        print("tick 2", flush=True)
+    evt_done.set()
+threading.Thread(target=late_worker, daemon=True).start()
+''')
+    kernel.run('s2-foreign', 'evt_go.set(); evt_first_done.wait(60)')
+    kernel.run('s2-later', 'evt_late.set(); evt_done.wait(60)')
+    kernel.drain_until_stream('tick 2')
+    kernel.settle()
+
+    # Scenario sanity: the first capture happened while s2-foreign (or, with
+    # ancestry-aware attribution, s2-spawn) was the resolvable parent.
+    assert kernel.stream_parent('tick 1') in ('s2-foreign', 's2-spawn')
+    return kernel
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="ipywidgets#4021: __exit__ never restores the parent that "
+           "__enter__ pinned with ip.set_parent(), so output printed after "
+           "the with block is still attributed to the captured (foreign) "
+           "cell on both ipykernel 6 and 7",
+)
+def test_parent_override_does_not_outlive_the_block(pin_scenario):
+    kernel = pin_scenario
+    # "late print" happens outside any context block, after the foreign cell
+    # finished.  It must not still be attributed to the foreign cell the
+    # widget captured earlier.  (Correct attribution is s2-spawn under
+    # ipykernel 6's thread ancestry, or the currently-executing s2-later via
+    # the global fallback on ipykernel 7.)
+    assert kernel.stream_parent('late print') != 's2-foreign', (
+        "output after the with block is still attributed to the foreign "
+        "cell captured inside it"
+    )
+
+
+@pytest.mark.xfail(
+    condition=IPYKERNEL_MAJOR >= 7,
+    strict=True,
+    reason="ipywidgets#4021: on ipykernel >= 7 the foreign cell's parent "
+           "grabbed at __enter__ is pinned to the thread's ContextVar, so "
+           "every later capture re-reads the long-finished foreign cell "
+           "instead of moving on",
+)
+def test_foreign_cell_parent_is_not_pinned_across_blocks(pin_scenario):
+    kernel = pin_scenario
+    comm_id = kernel.output_comm_id('s2-setup')
+    updates = [v for v in kernel.msg_id_updates(comm_id) if v]
+    # The last non-empty msg_id update corresponds to the second capture
+    # ("tick 2"), which ran during s2-later, well after s2-foreign finished.
+    # The widget must not still be capturing the foreign cell's msg_id.
+    assert updates, 'the widget never synced a msg_id'
+    assert updates[-1] != kernel.msg_id_of('s2-foreign'), (
+        "a later capture is still pinned to the long-finished foreign cell"
+    )

--- a/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output_parent_kernel.py
+++ b/python/ipywidgets/ipywidgets/widgets/tests/test_widget_output_parent_kernel.py
@@ -1,36 +1,30 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-"""Real-kernel regression tests for the parent handling from ipywidgets#4021.
+"""Real-kernel regression tests for the Output widget's parent handling.
 
 Unlike test_widget_output_parent.py (which emulates ipykernel with mocks),
 these tests start an actual ipykernel via jupyter_client, replay the
-problematic multi-threaded notebook scenarios, and assert on the parent
-attribution of the iopub messages the kernel really publishes.
+multi-threaded notebook scenarios that broke with the ``ip.set_parent()``
+approach of ipywidgets#4021, and assert on the parent attribution of the
+iopub messages the kernel really publishes.
 
 The scenarios are driven by threading.Events set from later cells, so the
 interleaving of cells and background threads is exact — no sleeps, no timing
 races.
 
-ipykernel 6 and 7 attribute background-thread output differently, so the
-expected failures are version-conditional:
+ipykernel 6 and 7 attribute background-thread output differently, and the
+assertions account for both:
 
 * ipykernel >= 7: ``OutStream.parent_header`` is a per-thread ContextVar
-  falling back to a process-global value; ``set_parent`` writes both.  The
-  ``ip.set_parent()`` call in ``Output.__enter__`` therefore (a) rewrites the
-  global fallback used by unrelated threads and (b) pins the capturing
-  thread's ContextVar forever (nothing restores it).
+  falling back to a process-global value.  A fresh thread resolves the
+  global (the newest cell); the widget pins the thread's ContextVar only
+  for the duration of a capture block and restores it on exit.
 * ipykernel 6: additionally tracks, for every thread, the cell that spawned
   it (``OutStream._thread_to_parent_header``, populated by a
   ``threading.Thread`` monkeypatch) and attributes thread output to that
-  cell.  The ContextVar written by ``set_parent`` takes priority over that
-  correct ancestry attribution, and the parent passed to ``set_parent`` comes
-  from ``shell.get_parent()``, which on ipykernel 6 is a process-global that
-  always points at the *newest* cell.
-
-Each test asserts the correct behavior and is marked xfail(strict=True) for
-the ipykernel versions where current main gets it wrong, mirroring the style
-of test_widget_output_parent.py.
+  cell.  Outside capture blocks that correct ancestry attribution must be
+  left untouched.
 """
 
 import time
@@ -132,6 +126,26 @@ class KernelHarness:
                     values.append(state['msg_id'])
         return values
 
+    def stream_captured_by(self, needle, comm_id):
+        """Whether the frontend Output hook would capture the stream message.
+
+        Replays the iopub messages in order (as a frontend would) tracking
+        the widget's synced msg_id; the message is captured iff its parent
+        equals the widget's msg_id when it arrives.
+        """
+        active = ''
+        for m in self.msgs:
+            if (m['msg_type'] == 'comm_msg'
+                    and m['content'].get('comm_id') == comm_id):
+                data = m['content'].get('data', {})
+                state = data.get('state') or {}
+                if data.get('method') == 'update' and 'msg_id' in state:
+                    active = state['msg_id']
+            elif (m['msg_type'] == 'stream'
+                    and needle in m['content']['text']):
+                return bool(active) and m['parent_header'].get('msg_id') == active
+        raise AssertionError('no stream message containing %r' % needle)
+
 
 @pytest.fixture(scope='module')
 def kernel():
@@ -190,42 +204,34 @@ threading.Thread(target=worker_b, daemon=True).start()
     return kernel
 
 
-@pytest.mark.xfail(
-    condition=IPYKERNEL_MAJOR >= 7,
-    strict=True,
-    reason="ipywidgets#4021: Output.__enter__ calls ip.set_parent() from the "
-           "capturing thread; on ipykernel >= 7 that rewrites the "
-           "process-global parent fallback, so output from unrelated threads "
-           "is attributed to the captured cell",
-)
 def test_unrelated_thread_output_not_attributed_to_captured_cell(clobber_scenario):
     kernel = clobber_scenario
     # Worker B has nothing to do with the widget.  Its print must not be
     # attributed to the cell worker A is capturing for.  (On ipykernel 6 B
-    # is protected by the thread-ancestry attribution and this passes; on
-    # ipykernel 7 B resolves the global fallback that A just rewrote.)
+    # is protected by the thread-ancestry attribution; on ipykernel 7 B
+    # resolves the global fallback, which capturing must not rewrite.)
     assert kernel.stream_parent('hello from B') != 's1-cell-a', (
         "unrelated thread output was attributed to the captured cell"
     )
 
 
-@pytest.mark.xfail(
-    condition=IPYKERNEL_MAJOR < 7,
-    strict=True,
-    reason="ipywidgets#4021: on ipykernel 6, shell.get_parent() is a "
-           "process-global that points at the newest cell, and set_parent "
-           "overrides ipykernel 6's correct thread-ancestry attribution "
-           "with it — so the capturing thread's output drifts to whatever "
-           "cell ran last instead of staying with its own cell",
-)
-def test_capturing_thread_output_stays_with_its_cell(clobber_scenario):
+def test_capturing_thread_output_lands_in_widget(clobber_scenario):
     kernel = clobber_scenario
-    # Worker A belongs to cell-a: it started there and captured there.  Its
-    # later output (from the re-entered context) should still be attributed
-    # to cell-a, not to whichever cell happens to be newest.
-    assert kernel.stream_parent('A second') == 's1-cell-a', (
-        "the capturing thread's output drifted to a newer, unrelated cell"
-    )
+    # The point of `with out:` from a thread: whatever parent the capture
+    # resolves, the thread's output inside the block must carry it, so the
+    # frontend hook routes the output into the widget.
+    comm_id = kernel.output_comm_id('s1-setup')
+    assert kernel.stream_captured_by('A first', comm_id)
+    assert kernel.stream_captured_by('A second', comm_id)
+    if IPYKERNEL_MAJOR < 7:
+        # ipykernel 6 knows the thread's own cell (ancestry); the capture
+        # must respect it rather than override it with the newest cell.
+        assert kernel.stream_parent('A second') == 's1-cell-a'
+    else:
+        # ipykernel 7 has no per-thread ancestry: a re-entered capture
+        # resolves the current global parent (the cell executing at
+        # re-entry) — transient by design, never pinned past the block.
+        assert kernel.stream_parent('A second') == 's1-cell-c'
 
 
 @pytest.fixture(scope='module')
@@ -272,13 +278,6 @@ threading.Thread(target=late_worker, daemon=True).start()
     return kernel
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="ipywidgets#4021: __exit__ never restores the parent that "
-           "__enter__ pinned with ip.set_parent(), so output printed after "
-           "the with block is still attributed to the captured (foreign) "
-           "cell on both ipykernel 6 and 7",
-)
 def test_parent_override_does_not_outlive_the_block(pin_scenario):
     kernel = pin_scenario
     # "late print" happens outside any context block, after the foreign cell
@@ -292,14 +291,6 @@ def test_parent_override_does_not_outlive_the_block(pin_scenario):
     )
 
 
-@pytest.mark.xfail(
-    condition=IPYKERNEL_MAJOR >= 7,
-    strict=True,
-    reason="ipywidgets#4021: on ipykernel >= 7 the foreign cell's parent "
-           "grabbed at __enter__ is pinned to the thread's ContextVar, so "
-           "every later capture re-reads the long-finished foreign cell "
-           "instead of moving on",
-)
 def test_foreign_cell_parent_is_not_pinned_across_blocks(pin_scenario):
     kernel = pin_scenario
     comm_id = kernel.output_comm_id('s2-setup')

--- a/python/ipywidgets/ipywidgets/widgets/widget_output.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_output.py
@@ -114,8 +114,8 @@ class Output(DOMWidget):
         return capture_decorator
 
     @staticmethod
-    def _resolve_parent_header(ip, kernel):
-        """The parent header to capture for the calling thread, or None.
+    def _resolve_parent(ip, kernel):
+        """The parent to capture for the calling thread: (parent, header).
 
         Prefer the parent the calling thread's stream output will actually
         be attributed to: ``OutStream.parent_header`` resolves per-thread
@@ -123,11 +123,13 @@ class Output(DOMWidget):
         per-thread ContextVar with a process-global fallback on 7). Fall
         back to the shell's parent request, then the kernel's, for streams
         that do not expose a parent (non-ipykernel kernels, redirected
-        stdout).
+        stdout). Returns the richest parent object available (a full
+        request when one exists, else a bare header) together with its
+        header, or (None, None).
         """
         header = getattr(sys.stdout, "parent_header", None)
         if isinstance(header, dict) and header.get("msg_id"):
-            return header
+            return header, header
 
         parent_request = None
         if ip is not None and hasattr(ip, "get_parent"):
@@ -148,21 +150,22 @@ class Output(DOMWidget):
         if isinstance(parent_request, dict):
             header = parent_request.get("header")
             if isinstance(header, dict) and header.get("msg_id"):
-                return header
-        return None
+                return parent_request, header
+        return None, None
 
     @staticmethod
     def _thread_parent_vars(ip):
         """ContextVars holding the calling thread's output parent.
 
-        ipykernel's ``OutStream`` (>= 6.18) and ``ZMQDisplayPublisher``
-        (>= 7) keep the per-thread parent in a ``_parent_header``
-        ContextVar. Setting it affects only the current thread and is
-        exactly reversible with the returned token — unlike
-        ``shell.set_parent``, which also rewrites process-global state
-        shared with every other thread. Objects without such a ContextVar
-        (other kernels such as xeus-python, redirected streams) are
-        skipped, leaving their behavior unchanged.
+        Fallback for ipykernel versions without the public
+        ``set_thread_parent`` API (ipython/ipykernel#1546): ``OutStream``
+        (>= 6.18) and ``ZMQDisplayPublisher`` (>= 7) keep the per-thread
+        parent in a ``_parent_header`` ContextVar. Setting it affects only
+        the current thread and is exactly reversible with the returned
+        token — unlike ``shell.set_parent``, which also rewrites
+        process-global state shared with every other thread. Objects
+        without such a ContextVar (other kernels such as xeus-python,
+        redirected streams) are skipped, leaving their behavior unchanged.
         """
         candidates = [sys.stdout, sys.stderr]
         if ip is not None:
@@ -172,6 +175,11 @@ class Output(DOMWidget):
             (getattr(obj, "_parent_header", None) for obj in candidates)
             if isinstance(var, ContextVar)
         ]
+
+    @staticmethod
+    def _reset_thread_parent_vars(pairs):
+        for var, token in reversed(pairs):
+            var.reset(token)
 
     def __enter__(self):
         """Called upon entering output widget context manager."""
@@ -183,17 +191,27 @@ class Output(DOMWidget):
         elif self.comm is not None and getattr(self.comm, 'kernel', None) is not None:
             kernel = self.comm.kernel
 
-        record = {'tokens': (), 'captured': False}
+        record = {'reset': None, 'tokens': None, 'captured': False}
         if kernel:
-            header = self._resolve_parent_header(ip, kernel)
+            parent, header = self._resolve_parent(ip, kernel)
             if header:
-                # Pin the calling thread's stream/display parents to the
-                # captured parent for the duration of the block, so output
-                # produced in this thread carries the same parent msg_id the
-                # frontend hook matches on.
-                record['tokens'] = tuple(
-                    (var, var.set(header)) for var in self._thread_parent_vars(ip)
-                )
+                # Pin the calling thread's parents to the captured parent
+                # for the duration of the block, so output produced in this
+                # thread carries the same parent msg_id the frontend hook
+                # matches on.
+                if hasattr(ip, "set_thread_parent") and hasattr(ip, "reset_thread_parent"):
+                    # ipykernel with the public thread-scoped parent API
+                    # (ipython/ipykernel#1546): thread-only and exactly
+                    # reversible, covering streams, display and get_parent.
+                    record['tokens'] = ip.set_thread_parent(parent)
+                    record['reset'] = ip.reset_thread_parent
+                else:
+                    # Older ipykernel: pin the stream/display ContextVars
+                    # directly.
+                    record['tokens'] = tuple(
+                        (var, var.set(header)) for var in self._thread_parent_vars(ip)
+                    )
+                    record['reset'] = self._reset_thread_parent_vars
                 record['captured'] = True
                 with self.__counter_lock:
                     self.__counter += 1
@@ -225,11 +243,11 @@ class Output(DOMWidget):
                     })
         self._flush()
         stack = getattr(self.__records, 'stack', None)
-        record = stack.pop() if stack else {'tokens': (), 'captured': False}
+        record = stack.pop() if stack else {'reset': None, 'tokens': None, 'captured': False}
         # Restore the thread's previous parents exactly; the override must
         # not outlive the block.
-        for var, token in reversed(record['tokens']):
-            var.reset(token)
+        if record['reset'] is not None:
+            record['reset'](record['tokens'])
         if record['captured']:
             # Only decrement when the matching __enter__ captured, so the
             # counter stays balanced and msg_id cleanup always fires.

--- a/python/ipywidgets/ipywidgets/widgets/widget_output.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_output.py
@@ -7,6 +7,8 @@ Represents a widget that can be used to display output within the widget area.
 """
 
 import sys
+import threading
+from contextvars import ContextVar
 from functools import wraps
 
 from .domwidget import DOMWidget
@@ -62,6 +64,13 @@ class Output(DOMWidget):
 
     __counter = 0
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__counter_lock = threading.Lock()
+        # Per-thread stack of capture records so nested/threaded enter/exit
+        # pairs stay balanced and each thread restores exactly what it set.
+        self.__records = threading.local()
+
     def clear_output(self, *pargs, **kwargs):
         """
         Clear the content of the output widget.
@@ -104,6 +113,66 @@ class Output(DOMWidget):
             return inner
         return capture_decorator
 
+    @staticmethod
+    def _resolve_parent_header(ip, kernel):
+        """The parent header to capture for the calling thread, or None.
+
+        Prefer the parent the calling thread's stream output will actually
+        be attributed to: ``OutStream.parent_header`` resolves per-thread
+        state on ipykernel >= 6 (thread-ancestry map on ipykernel 6, a
+        per-thread ContextVar with a process-global fallback on 7). Fall
+        back to the shell's parent request, then the kernel's, for streams
+        that do not expose a parent (non-ipykernel kernels, redirected
+        stdout).
+        """
+        header = getattr(sys.stdout, "parent_header", None)
+        if isinstance(header, dict) and header.get("msg_id"):
+            return header
+
+        parent_request = None
+        if ip is not None and hasattr(ip, "get_parent"):
+            shell_parent = ip.get_parent()
+            # Only accept a full parent *request*; ipykernel display
+            # publishers store bare header dicts, which must not shadow the
+            # kernel fallback below.
+            if isinstance(shell_parent, dict) and shell_parent.get("header"):
+                parent_request = shell_parent
+        if parent_request is None:
+            if hasattr(kernel, "get_parent"):
+                # ipykernel >= 6 keeps parent requests on the kernel.
+                parent_request = kernel.get_parent()
+            elif hasattr(kernel, "_parent_header"):
+                # ipykernel < 6: kernel._parent_header is the parent *request*
+                parent_request = kernel._parent_header
+
+        if isinstance(parent_request, dict):
+            header = parent_request.get("header")
+            if isinstance(header, dict) and header.get("msg_id"):
+                return header
+        return None
+
+    @staticmethod
+    def _thread_parent_vars(ip):
+        """ContextVars holding the calling thread's output parent.
+
+        ipykernel's ``OutStream`` (>= 6.18) and ``ZMQDisplayPublisher``
+        (>= 7) keep the per-thread parent in a ``_parent_header``
+        ContextVar. Setting it affects only the current thread and is
+        exactly reversible with the returned token — unlike
+        ``shell.set_parent``, which also rewrites process-global state
+        shared with every other thread. Objects without such a ContextVar
+        (other kernels such as xeus-python, redirected streams) are
+        skipped, leaving their behavior unchanged.
+        """
+        candidates = [sys.stdout, sys.stderr]
+        if ip is not None:
+            candidates.append(getattr(ip, "display_pub", None))
+        return [
+            var for var in
+            (getattr(obj, "_parent_header", None) for obj in candidates)
+            if isinstance(var, ContextVar)
+        ]
+
     def __enter__(self):
         """Called upon entering output widget context manager."""
         self._flush()
@@ -114,32 +183,25 @@ class Output(DOMWidget):
         elif self.comm is not None and getattr(self.comm, 'kernel', None) is not None:
             kernel = self.comm.kernel
 
+        record = {'tokens': (), 'captured': False}
         if kernel:
-            parent_request = None
-            if ip and hasattr(ip, "get_parent"):
-                # Prefer the shell parent request so display hooks and streams
-                # are refreshed from the same message below.
-                shell_parent = ip.get_parent()
-                if shell_parent:
-                    parent_request = shell_parent
-            if not parent_request:
-                if hasattr(kernel, "get_parent"):
-                    # Fallback for contexts without an active shell parent:
-                    # ipykernel >= 6 keeps parent requests on the kernel.
-                    kernel_parent = kernel.get_parent()
-                elif hasattr(kernel, "_parent_header"):
-                    # ipykernel < 6: kernel._parent_header is the parent *request*
-                    kernel_parent = kernel._parent_header
-                else:
-                    kernel_parent = None
-                if kernel_parent:
-                    parent_request = kernel_parent
-
-            if parent_request and parent_request.get("header"):
-                if ip and hasattr(ip, "set_parent"):
-                    ip.set_parent(parent_request)
-                self.msg_id = parent_request["header"]["msg_id"]
-                self.__counter += 1
+            header = self._resolve_parent_header(ip, kernel)
+            if header:
+                # Pin the calling thread's stream/display parents to the
+                # captured parent for the duration of the block, so output
+                # produced in this thread carries the same parent msg_id the
+                # frontend hook matches on.
+                record['tokens'] = tuple(
+                    (var, var.set(header)) for var in self._thread_parent_vars(ip)
+                )
+                record['captured'] = True
+                with self.__counter_lock:
+                    self.__counter += 1
+                self.msg_id = header['msg_id']
+        stack = getattr(self.__records, 'stack', None)
+        if stack is None:
+            stack = self.__records.stack = []
+        stack.append(record)
 
     def __exit__(self, etype, evalue, tb):
         """Called upon exiting output widget context manager."""
@@ -162,9 +224,19 @@ class Output(DOMWidget):
                     u'ename': etype.__name__
                     })
         self._flush()
-        self.__counter -= 1
-        if self.__counter == 0:
-            self.msg_id = ''
+        stack = getattr(self.__records, 'stack', None)
+        record = stack.pop() if stack else {'tokens': (), 'captured': False}
+        # Restore the thread's previous parents exactly; the override must
+        # not outlive the block.
+        for var, token in reversed(record['tokens']):
+            var.reset(token)
+        if record['captured']:
+            # Only decrement when the matching __enter__ captured, so the
+            # counter stays balanced and msg_id cleanup always fires.
+            with self.__counter_lock:
+                self.__counter -= 1
+                if self.__counter == 0:
+                    self.msg_id = ''
         # suppress exceptions when in IPython, since they are shown above,
         # otherwise let someone else handle it
         return True if kernel else None

--- a/python/ipywidgets/ipywidgets/widgets/widget_output.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_output.py
@@ -129,8 +129,8 @@ class Output(DOMWidget):
         return capture_decorator
 
     @staticmethod
-    def _resolve_parent_header(ip, kernel):
-        """The parent header to capture for the calling thread, or None.
+    def _resolve_parent(ip, kernel):
+        """The parent to capture for the calling thread: (parent, header).
 
         Prefer the parent the calling thread's stream output will actually
         be attributed to: ``OutStream.parent_header`` resolves per-thread
@@ -138,11 +138,13 @@ class Output(DOMWidget):
         per-thread ContextVar with a process-global fallback on 7). Fall
         back to the shell's parent request, then the kernel's, for streams
         that do not expose a parent (non-ipykernel kernels, redirected
-        stdout).
+        stdout). Returns the richest parent object available (a full
+        request when one exists, else a bare header) together with its
+        header, or (None, None).
         """
         header = getattr(sys.stdout, "parent_header", None)
         if isinstance(header, dict) and header.get("msg_id"):
-            return header
+            return header, header
 
         parent_request = None
         if ip is not None and hasattr(ip, "get_parent"):
@@ -160,25 +162,22 @@ class Output(DOMWidget):
         if isinstance(parent_request, dict):
             header = parent_request.get("header")
             if isinstance(header, dict) and header.get("msg_id"):
-                return header
-        return None
+                return parent_request, header
+        return None, None
 
     @staticmethod
     def _thread_parent_vars(ip):
         """ContextVars holding the calling thread's output parent.
 
-        ipykernel's ``OutStream`` (>= 6.18) and ``ZMQDisplayPublisher``
-        (>= 7) keep the per-thread parent in a ``_parent_header``
-        ContextVar. Setting it affects only the current thread and is
-        exactly reversible with the returned token — unlike
-        ``shell.set_parent``, which also rewrites process-global state
-        shared with every other thread. Objects without such a ContextVar
-        (other kernels such as xeus-python, redirected streams) are
-        skipped, leaving their behavior unchanged.
-
-        Once ipython/ipykernel#1546 (a public thread-scoped
-        ``set_thread_parent``/``reset_thread_parent`` API) is merged,
-        prefer that API over touching these ContextVars directly.
+        Fallback for ipykernel versions without the public
+        ``set_thread_parent`` API (ipython/ipykernel#1546): ``OutStream``
+        (>= 6.18) and ``ZMQDisplayPublisher`` (>= 7) keep the per-thread
+        parent in a ``_parent_header`` ContextVar. Setting it affects only
+        the current thread and is exactly reversible with the returned
+        token — unlike ``shell.set_parent``, which also rewrites
+        process-global state shared with every other thread. Objects
+        without such a ContextVar (other kernels such as xeus-python,
+        redirected streams) are skipped, leaving their behavior unchanged.
         """
         candidates = [sys.stdout, sys.stderr]
         if ip is not None:
@@ -188,6 +187,11 @@ class Output(DOMWidget):
             (getattr(obj, "_parent_header", None) for obj in candidates)
             if isinstance(var, ContextVar)
         ]
+
+    @staticmethod
+    def _reset_thread_parent_vars(pairs):
+        for var, token in reversed(pairs):
+            var.reset(token)
 
     def _show_exception(self, etype, evalue, tb):
         """Display an exception through the kernel, if one is available.
@@ -233,18 +237,29 @@ class Output(DOMWidget):
         elif self.comm is not None and getattr(self.comm, 'kernel', None) is not None:
             kernel = self.comm.kernel
 
-        tokens = ()
+        reset = None
+        tokens = None
         captured = False
         if kernel:
-            header = self._resolve_parent_header(ip, kernel)
+            parent, header = self._resolve_parent(ip, kernel)
             if header:
-                # Pin the calling thread's stream/display parents to the
-                # captured parent for the duration of the block, so output
-                # produced in this thread carries the same parent msg_id the
-                # frontend hook matches on.
-                tokens = tuple(
-                    (var, var.set(header)) for var in self._thread_parent_vars(ip)
-                )
+                # Pin the calling thread's parents to the captured parent
+                # for the duration of the block, so output produced in this
+                # thread carries the same parent msg_id the frontend hook
+                # matches on.
+                if hasattr(ip, "set_thread_parent") and hasattr(ip, "reset_thread_parent"):
+                    # ipykernel with the public thread-scoped parent API
+                    # (ipython/ipykernel#1546): thread-only and exactly
+                    # reversible, covering streams, display and get_parent.
+                    tokens = ip.set_thread_parent(parent)
+                    reset = ip.reset_thread_parent
+                else:
+                    # Older ipykernel: pin the stream/display ContextVars
+                    # directly.
+                    tokens = tuple(
+                        (var, var.set(header)) for var in self._thread_parent_vars(ip)
+                    )
+                    reset = self._reset_thread_parent_vars
                 captured = True
                 with self.__counter_lock:
                     self.__counter += 1
@@ -261,8 +276,8 @@ class Output(DOMWidget):
             self._flush()
             # Restore the thread's previous parents exactly; the override
             # must not outlive the block.
-            for var, token in reversed(tokens):
-                var.reset(token)
+            if reset is not None:
+                reset(tokens)
             if captured:
                 with self.__counter_lock:
                     self.__counter -= 1

--- a/python/ipywidgets/ipywidgets/widgets/widget_output.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_output.py
@@ -139,13 +139,10 @@ class Output(DOMWidget):
             # kernel fallback below.
             if isinstance(shell_parent, dict) and shell_parent.get("header"):
                 parent_request = shell_parent
-        if parent_request is None:
-            if hasattr(kernel, "get_parent"):
-                # ipykernel >= 6 keeps parent requests on the kernel.
-                parent_request = kernel.get_parent()
-            elif hasattr(kernel, "_parent_header"):
-                # ipykernel < 6: kernel._parent_header is the parent *request*
-                parent_request = kernel._parent_header
+        if parent_request is None and hasattr(kernel, "get_parent"):
+            # ipykernel >= 6 and xeus-python keep parent requests on the
+            # kernel.
+            parent_request = kernel.get_parent()
 
         if isinstance(parent_request, dict):
             header = parent_request.get("header")

--- a/python/ipywidgets/ipywidgets/widgets/widget_output.py
+++ b/python/ipywidgets/ipywidgets/widgets/widget_output.py
@@ -8,6 +8,7 @@ Represents a widget that can be used to display output within the widget area.
 
 import sys
 import threading
+from contextlib import contextmanager
 from contextvars import ContextVar
 from functools import wraps
 
@@ -21,6 +22,20 @@ from IPython.core.interactiveshell import InteractiveShell
 from IPython.display import clear_output
 from IPython import get_ipython
 import traceback
+
+
+class _CaptureRecords(threading.local):
+    """Per-thread stack of entered capture context managers.
+
+    Carries the context manager from ``Output.__enter__`` to the matching
+    ``Output.__exit__`` when the widget itself is used as a context
+    manager. ``threading.local`` subclasses run ``__init__`` once per
+    thread on that thread's first access, so every thread sees its own
+    freshly initialized stack.
+    """
+    def __init__(self):
+        self.stack = []
+
 
 @register
 class Output(DOMWidget):
@@ -69,7 +84,7 @@ class Output(DOMWidget):
         self.__counter_lock = threading.Lock()
         # Per-thread stack of capture records so nested/threaded enter/exit
         # pairs stay balanced and each thread restores exactly what it set.
-        self.__records = threading.local()
+        self.__records = _CaptureRecords()
 
     def clear_output(self, *pargs, **kwargs):
         """
@@ -82,7 +97,7 @@ class Output(DOMWidget):
             If True, wait to clear the output until new output is
             available to replace it. Default: False
         """
-        with self:
+        with self.capture_output():
             clear_output(*pargs, **kwargs)
 
     # PY3: Force passing clear_output and clear_kwargs as kwargs
@@ -108,14 +123,14 @@ class Output(DOMWidget):
             def inner(*args, **kwargs):
                 if clear_output:
                     self.clear_output(*clear_args, **clear_kwargs)
-                with self:
+                with self.capture_output():
                     return func(*args, **kwargs)
             return inner
         return capture_decorator
 
     @staticmethod
-    def _resolve_parent(ip, kernel):
-        """The parent to capture for the calling thread: (parent, header).
+    def _resolve_parent_header(ip, kernel):
+        """The parent header to capture for the calling thread, or None.
 
         Prefer the parent the calling thread's stream output will actually
         be attributed to: ``OutStream.parent_header`` resolves per-thread
@@ -123,13 +138,11 @@ class Output(DOMWidget):
         per-thread ContextVar with a process-global fallback on 7). Fall
         back to the shell's parent request, then the kernel's, for streams
         that do not expose a parent (non-ipykernel kernels, redirected
-        stdout). Returns the richest parent object available (a full
-        request when one exists, else a bare header) together with its
-        header, or (None, None).
+        stdout).
         """
         header = getattr(sys.stdout, "parent_header", None)
         if isinstance(header, dict) and header.get("msg_id"):
-            return header, header
+            return header
 
         parent_request = None
         if ip is not None and hasattr(ip, "get_parent"):
@@ -147,22 +160,25 @@ class Output(DOMWidget):
         if isinstance(parent_request, dict):
             header = parent_request.get("header")
             if isinstance(header, dict) and header.get("msg_id"):
-                return parent_request, header
-        return None, None
+                return header
+        return None
 
     @staticmethod
     def _thread_parent_vars(ip):
         """ContextVars holding the calling thread's output parent.
 
-        Fallback for ipykernel versions without the public
-        ``set_thread_parent`` API (ipython/ipykernel#1546): ``OutStream``
-        (>= 6.18) and ``ZMQDisplayPublisher`` (>= 7) keep the per-thread
-        parent in a ``_parent_header`` ContextVar. Setting it affects only
-        the current thread and is exactly reversible with the returned
-        token — unlike ``shell.set_parent``, which also rewrites
-        process-global state shared with every other thread. Objects
-        without such a ContextVar (other kernels such as xeus-python,
-        redirected streams) are skipped, leaving their behavior unchanged.
+        ipykernel's ``OutStream`` (>= 6.18) and ``ZMQDisplayPublisher``
+        (>= 7) keep the per-thread parent in a ``_parent_header``
+        ContextVar. Setting it affects only the current thread and is
+        exactly reversible with the returned token — unlike
+        ``shell.set_parent``, which also rewrites process-global state
+        shared with every other thread. Objects without such a ContextVar
+        (other kernels such as xeus-python, redirected streams) are
+        skipped, leaving their behavior unchanged.
+
+        Once ipython/ipykernel#1546 (a public thread-scoped
+        ``set_thread_parent``/``reset_thread_parent`` API) is merged,
+        prefer that API over touching these ContextVars directly.
         """
         candidates = [sys.stdout, sys.stderr]
         if ip is not None:
@@ -173,13 +189,42 @@ class Output(DOMWidget):
             if isinstance(var, ContextVar)
         ]
 
-    @staticmethod
-    def _reset_thread_parent_vars(pairs):
-        for var, token in reversed(pairs):
-            var.reset(token)
+    def _show_exception(self, etype, evalue, tb):
+        """Display an exception through the kernel, if one is available.
 
-    def __enter__(self):
-        """Called upon entering output widget context manager."""
+        Returns True if the exception was displayed (so the caller should
+        suppress it), False to let it propagate.
+        """
+        ip = get_ipython()
+        if ip:
+            ip.showtraceback((etype, evalue, tb), tb_offset=0)
+            return True
+        if (self.comm is not None and
+                getattr(self.comm, "kernel", None) is not None and
+                # Check if it's ipykernel
+                getattr(self.comm.kernel, "send_response", None) is not None):
+            kernel = self.comm.kernel
+            kernel.send_response(kernel.iopub_socket,
+                                 u'error',
+                                 {
+                u'traceback': ["".join(traceback.format_exception(etype, evalue, tb))],
+                u'evalue': repr(evalue.args),
+                u'ename': etype.__name__
+                })
+            return True
+        return False
+
+    @contextmanager
+    def capture_output(self):
+        """Return a fresh context manager that captures output into this widget.
+
+        Each call returns an independent context manager, so per-entry
+        state lives in its own frame: nested blocks, threads, and
+        interleaved async tasks each pair their own enter/exit without
+        shared bookkeeping. Using the widget itself as a context manager
+        (``with out:``) is equivalent, entering a context manager from
+        this method under the hood.
+        """
         self._flush()
         ip = get_ipython()
         kernel = None
@@ -188,73 +233,54 @@ class Output(DOMWidget):
         elif self.comm is not None and getattr(self.comm, 'kernel', None) is not None:
             kernel = self.comm.kernel
 
-        record = {'reset': None, 'tokens': None, 'captured': False}
+        tokens = ()
+        captured = False
         if kernel:
-            parent, header = self._resolve_parent(ip, kernel)
+            header = self._resolve_parent_header(ip, kernel)
             if header:
-                # Pin the calling thread's parents to the captured parent
-                # for the duration of the block, so output produced in this
-                # thread carries the same parent msg_id the frontend hook
-                # matches on.
-                if hasattr(ip, "set_thread_parent") and hasattr(ip, "reset_thread_parent"):
-                    # ipykernel with the public thread-scoped parent API
-                    # (ipython/ipykernel#1546): thread-only and exactly
-                    # reversible, covering streams, display and get_parent.
-                    record['tokens'] = ip.set_thread_parent(parent)
-                    record['reset'] = ip.reset_thread_parent
-                else:
-                    # Older ipykernel: pin the stream/display ContextVars
-                    # directly.
-                    record['tokens'] = tuple(
-                        (var, var.set(header)) for var in self._thread_parent_vars(ip)
-                    )
-                    record['reset'] = self._reset_thread_parent_vars
-                record['captured'] = True
+                # Pin the calling thread's stream/display parents to the
+                # captured parent for the duration of the block, so output
+                # produced in this thread carries the same parent msg_id the
+                # frontend hook matches on.
+                tokens = tuple(
+                    (var, var.set(header)) for var in self._thread_parent_vars(ip)
+                )
+                captured = True
                 with self.__counter_lock:
                     self.__counter += 1
                 self.msg_id = header['msg_id']
-        stack = getattr(self.__records, 'stack', None)
-        if stack is None:
-            stack = self.__records.stack = []
-        stack.append(record)
+        try:
+            yield
+        except BaseException:
+            # Show the exception in the kernel's usual way while the parent
+            # is still pinned, so it lands in this widget; suppress it only
+            # if it was shown, otherwise let someone else handle it.
+            if not self._show_exception(*sys.exc_info()):
+                raise
+        finally:
+            self._flush()
+            # Restore the thread's previous parents exactly; the override
+            # must not outlive the block.
+            for var, token in reversed(tokens):
+                var.reset(token)
+            if captured:
+                with self.__counter_lock:
+                    self.__counter -= 1
+                    if self.__counter == 0:
+                        self.msg_id = ''
+
+    def __enter__(self):
+        """Called upon entering output widget context manager."""
+        cm = self.capture_output()
+        cm.__enter__()
+        self.__records.stack.append(cm)
 
     def __exit__(self, etype, evalue, tb):
         """Called upon exiting output widget context manager."""
-        kernel = None
-        if etype is not None:
-            ip = get_ipython()
-            if ip:
-                kernel = ip
-                ip.showtraceback((etype, evalue, tb), tb_offset=0)
-            elif (self.comm is not None and
-                    getattr(self.comm, "kernel", None) is not None and
-                    # Check if it's ipykernel
-                    getattr(self.comm.kernel, "send_response", None) is not None):
-                kernel = self.comm.kernel
-                kernel.send_response(kernel.iopub_socket,
-                                     u'error',
-                                     {
-                    u'traceback': ["".join(traceback.format_exception(etype, evalue, tb))],
-                    u'evalue': repr(evalue.args),
-                    u'ename': etype.__name__
-                    })
-        self._flush()
-        stack = getattr(self.__records, 'stack', None)
-        record = stack.pop() if stack else {'reset': None, 'tokens': None, 'captured': False}
-        # Restore the thread's previous parents exactly; the override must
-        # not outlive the block.
-        if record['reset'] is not None:
-            record['reset'](record['tokens'])
-        if record['captured']:
-            # Only decrement when the matching __enter__ captured, so the
-            # counter stays balanced and msg_id cleanup always fires.
-            with self.__counter_lock:
-                self.__counter -= 1
-                if self.__counter == 0:
-                    self.msg_id = ''
-        # suppress exceptions when in IPython, since they are shown above,
-        # otherwise let someone else handle it
-        return True if kernel else None
+        stack = self.__records.stack
+        if not stack:
+            return None
+        return stack.pop().__exit__(etype, evalue, tb)
 
     def _flush(self):
         """Flush stdout and stderr buffers."""


### PR DESCRIPTION
Follow-up to #4021, which modified `Output.__enter__` to resolve and pin parent requests via `ip.set_parent()`. This PR documents the problems that change introduced, adds regression tests for them (mock-based and against real kernels), and fixes them.

Drops support for ipykernel < 6 (last released Oct 2021).

## Problems found (all fixed here)

1. **Cross-thread clobber** — `ip.set_parent()` called from a capturing background thread rewrites ipykernel's *process-global* parent fallback, so output from unrelated threads gets attributed to the captured cell (ipykernel 7), and on ipykernel 6 it overrides the kernel's correct per-thread ancestry attribution, so the capturing thread's own output drifts to whatever cell ran last.
2. **Override outlives the block** — `__exit__` never restores what `__enter__` overrode; the thread stays pinned (ipykernel 7) or context-overridden (ipykernel 6) after the `with` block ends.
3. **Foreign cell pinned** — a parent grabbed from a different, currently-executing cell (a pre-existing transient issue) is pinned to the thread on ipykernel 7: the misattribution outlives the foreign cell instead of self-correcting.
4. **Fallback ordering + counter** — a truthy header-*shaped* shell parent (a bare header dict, the shape ipykernel display publishers store) is committed before the `.get("header")` check, silently disabling capture even when the kernel fallback holds a usable request; in that case `__enter__` skips the counter increment but `__exit__` still decrements, so the counter goes negative and `msg_id` is never cleared again.
5. **Untested fallback branch** — the kernel-fallback branch of the new code had no test coverage (the #4021 unit test's shell parent is always truthy, so its kernel mocks were dead weight).

## The fix

`Output.__enter__` no longer calls `ip.set_parent()` (a shell-wide mutation that also rewrites ipykernel's process-global parent fallbacks). Instead it:

- **Resolves** the parent from the calling thread's *effective* stream parent (`sys.stdout.parent_header` — thread-ancestry on ipykernel 6, per-thread ContextVar with global fallback on 7), falling back to the shell's parent request (now shape-checked, fixing problem 4) and then the kernel's.
- **Prefers ipykernel's public thread-scoped API when present**: on kernels with ipython/ipykernel#1546, `__enter__` delegates to `ip.set_thread_parent(parent)` (passing the full parent request when available, so `ip.get_parent()` also reflects the capture inside the block) and `__exit__` calls `ip.reset_thread_parent(tokens)` — thread-only, exactly reversible, covering every parent-bearing object the kernel knows about.
- **Falls back to pinning directly** on released ipykernels without that API: sets the `_parent_header` ContextVars ipykernel exposes on `OutStream` (and `ZMQDisplayPublisher` on ipykernel 7), keeping the tokens; `__exit__` resets them, so the override affects only the capturing thread and never outlives the block (fixing problems 1–3). Objects without such a ContextVar — non-ipykernel kernels like xeus-python, redirected streams — are skipped, leaving them exactly as before (re-verified against a live xeus-python 0.19.0 kernel).
- **Balances the counter** with per-thread capture records and a lock: `__exit__` only decrements when the matching `__enter__` captured (fixing problem 4's counter half).

Design note: a restore done via `ip.set_parent(saved)` would itself write a stale parent into the process-global fallback — the ContextVar token reset is the only exactly-reversible mechanism, which is why both paths route through ContextVar tokens rather than the public `set_parent`.

Verified against real kernels on all three mechanisms: ipykernel 6.29.5 and 7.3.0 (fallback path) and a kernel built from the ipython/ipykernel#1546 branch (public-API path — a live probe confirms each capture block performs exactly one `set_thread_parent`/`reset_thread_parent` pair).

**Remaining limitation** (inherent, pre-dates #4021): on ipykernel 7 a fresh thread has no identity of its own, so its first capture during a foreign cell still transiently grabs that cell's parent (see scenario 3). Fully fixing that needs ipykernel-side support, which is a matter of upstream design intent — see below.

## Upstream context

ipykernel 6.29.0 attributed each thread's output to its spawning cell (thread-ancestry tracking plus a `threading.Thread` hook, ipython/ipykernel#1186); that machinery survived into 7.0.0 but was deliberately removed in 7.1.0 (ipython/ipykernel#1451), following ipython/ipykernel#1289's argument that the spawning-cell default was "more often incorrect than correct" (IPython Parallel threads responding to main-thread actions; `ThreadPoolExecutor` workers spawned lazily by whichever cell submits first). The replacement contract is explicit: a thread-local parent persists if a thread sets one, otherwise the global (newest-cell) fallback applies. #4021 followed that prescription — call `set_parent` from the thread — and ran into its acknowledged gap: `set_parent` also rewrites the process-global fallback, and there is no restore/clear API. ipython/ipykernel#1546 adds that missing piece as public API (`set_thread_parent`/`reset_thread_parent`/`parent_override`); this PR uses it when available and carries a widget-side implementation of the same tokens as a fallback for released ipykernels. The remaining limitation above is likewise the intended upstream default (threads without an explicitly-set parent follow the newest cell), not something ipywidgets can change.

## Manual verification notebooks

The scenarios are **fully deterministic**: background threads and cells hand off with `threading.Event`s — no sleeps, no timing races. Run the cells in order in JupyterLab against ipykernel 6.29.5 and 7.x. Every table entry was measured from raw iopub traces of these exact cells against real kernels on all six configurations (2 kernel versions × pre-#4021, post-#4021 main, and this PR).

Reading the tables: "attributed to cell N" means the stream message's parent header is cell N's `execute_request`; "in the widget" means the message's parent matched the widget's `msg_id` when it arrived, so the frontend Output hook captures it; output attributed to an already-finished cell is dropped by JupyterLab ("appears nowhere").

### Scenario 1 — unrelated thread must not be contaminated (problem 1)

```python
# Cell 1
import threading
from ipywidgets import Output
out1 = Output()
out1
```
```python
# Cell 2 — worker A captures now, and captures again when released by cell 4
evt_release_a = threading.Event()
evt_a_done = threading.Event()
evt_release_b = threading.Event()
evt_b_done = threading.Event()
_first = threading.Event()

def worker_a():
    with out1:
        print("A first", flush=True)
    _first.set()
    evt_release_a.wait(60)
    with out1:
        print("A second", flush=True)
    evt_a_done.set()

threading.Thread(target=worker_a, daemon=True).start()
_first.wait(60)          # A's first capture happens during THIS cell
```
```python
# Cell 3 — unrelated worker B, prints only when released
def worker_b():
    evt_release_b.wait(60)
    print("hello from B", flush=True)
    evt_b_done.set()

threading.Thread(target=worker_b, daemon=True).start()
```
```python
# Cell 4 — A re-enters the widget context while THIS cell runs; B then
# prints, also while THIS cell is still running
evt_release_a.set()
evt_a_done.wait(60)
evt_release_b.set()
evt_b_done.wait(60)
print("cell 4 done")
```

| | pre-#4021 | post-#4021 (main) | **with this PR** |
|---|---|---|---|
| **ipykernel 7** | `A first`/`A second` in the widget, but `A second` attributed to cell 4 (drift; capture was timing-dependent in general — the flakiness #4021 targeted). `hello from B` attributed to cell 4, appears under cell 4. | `A first`/`A second` in the widget, stably attributed to cell 2. **But `hello from B` is attributed to long-finished cell 2 and appears nowhere** — the global fallback was clobbered. | `A first`/`A second` in the widget (`A second` attributed to cell 4, the cell current at re-entry — transient by design, and capture is deterministic). **`hello from B` attributed to cell 4, appears under cell 4** — unrelated thread untouched. |
| **ipykernel 6** | `A first` in the widget. **`A second` appears nowhere** (attributed to cell 2 via thread ancestry — correct — but `msg_id` drifted to cell 4; the original bug). `hello from B` attributed to its spawn cell 3, appears nowhere. | `A first`/`A second` in the widget, but `A second` attributed to cell 4 — ancestry overridden. `hello from B` attributed to cell 3, appears nowhere. | **`A first`/`A second` in the widget AND attributed to cell 2, the thread's own cell** — capture works and ancestry is respected. `hello from B` attributed to cell 3, appears nowhere (stock ipykernel 6 behavior). |

### Scenario 2 — the override must not outlive the `with` block (problem 2)

```python
# Cell 5
out2 = Output()
out2
```
```python
# Cell 6 — worker C captures once during THIS cell, then waits
evt_release_c = threading.Event()
evt_c_done = threading.Event()
_in = threading.Event()

def worker_c():
    with out2:
        print("inside", flush=True)
    _in.set()
    evt_release_c.wait(60)
    print("outside", flush=True)   # AFTER the block, from the same thread
    evt_c_done.set()

threading.Thread(target=worker_c, daemon=True).start()
_in.wait(60)
```
```python
# Cell 7 — "outside" is printed while THIS cell is running
evt_release_c.set()
evt_c_done.wait(60)
print("cell 7 done")
```

| | pre-#4021 | post-#4021 (main) | **with this PR** |
|---|---|---|---|
| **ipykernel 7** | `outside` attributed to cell 7, appears under cell 7. | **`outside` attributed to finished cell 6, appears nowhere** — the pin was never undone. | `outside` attributed to cell 7, **appears under cell 7** — the ContextVar token reset restores the thread exactly. |
| **ipykernel 6** | `outside` attributed to cell 6 via thread ancestry, appears nowhere — stock behavior. | Same visible outcome, but via the leaked ContextVar override (scenario 3 separates the two). | `outside` attributed to cell 6 via ancestry again — the override is fully reverted on exit (the real-kernel test, where spawn and capture cells differ, verifies the mechanism). |

### Scenario 3 — a foreign cell's parent must stay transient (problems 3 and 1)

```python
# Cell 8
out3 = Output()
out3
evt_go = threading.Event()
evt_tick1_done = threading.Event()
evt_go2 = threading.Event()
evt_in2 = threading.Event()
evt_hold = threading.Event()
evt_done = threading.Event()

def late_worker():
    evt_go.wait(60)
    with out3:
        print("tick 1", flush=True)
    evt_tick1_done.set()
    evt_go2.wait(60)
    with out3:
        print("tick 2", flush=True)
        evt_in2.set()
        evt_hold.wait(60)          # hold the block open while cell 10 prints
    evt_done.set()

threading.Thread(target=late_worker, daemon=True).start()
```
```python
# Cell 9 — the "foreign" cell: the worker's first capture happens DURING this cell
evt_go.set()
evt_tick1_done.wait(60)
print("cell 9 done")
```
```python
# Cell 10 — the worker re-enters DURING this cell and holds its block open
# while this cell prints
evt_go2.set()
evt_in2.wait(60)
print("cell 10 progress", flush=True)
evt_hold.set()
evt_done.wait(60)
```

| | pre-#4021 | post-#4021 (main) | **with this PR** |
|---|---|---|---|
| **ipykernel 7** | Ticks in the widget, attributed to the cell executing at the time (9, then 10) — self-correcting. **`cell 10 progress` swallowed into the widget** (foreign grab). | Ticks in the widget but **attributed to cell 9 forever** (pinned). `cell 10 progress` under cell 10 (the pin coincidentally avoids the swallow, at the cost of permanent dead-cell attribution — the cause of scenario 2's vanish). | Ticks in the widget, attributed to cells 9/10 — transient again, nothing pinned. **`cell 10 progress` is still swallowed** — the remaining limitation: a fresh thread on ipykernel 7 has no identity, so its capture grabs the executing cell; see "Upstream context". |
| **ipykernel 6** | Ticks appear **nowhere** (ancestry vs drifting `msg_id` — the original bug). **`cell 10 progress` swallowed into the widget.** | Ticks in the widget, attributed to cells 9/10 (drift). **`cell 10 progress` still swallowed.** | **Ticks in the widget AND attributed to spawn cell 8** (ancestry respected). **`cell 10 progress` appears under cell 10 — the foreground swallow is fixed.** |

## Test suite in this PR

All tests assert the correct (fixed) behavior and pass; before the fix commit they were `xfail(strict=True)` markers documenting the regressions, and each flipped to a strict XPASS exactly at the fix — and, run against the pre-#4021 tree, at that boundary too.

### Mock-based tests (`test_widget_output_parent.py`)

Uses a `FakeInteractiveShell` emulating ipykernel's parent bookkeeping (per-thread ContextVar whose setter also writes a process-global fallback, verified against ipykernel 7.3.0), with single-worker `ThreadPoolExecutor`s for deterministic interleaving.

- **Problems 1–3**: capturing from a thread leaves the global fallback and other threads untouched, nothing outlives the block, foreign grabs stay transient
- **Problem 4**: header-shaped shell parents fall through to the kernel fallback; the counter stays balanced when a block captures nothing
- **Problem 5**: the kernel-fallback branch works — and `ip.set_parent` is never called (also enforced in `test_widget_output.py`)
- **Public API selection**: with ipykernel#1546's `set_thread_parent`/`reset_thread_parent` present, the widget delegates to them (full request in, opaque tokens round-tripped) and touches nothing else
- **Pinning mechanics** (fallback path): the stream's ContextVar is set to the captured header inside the block and token-reset on exit; the thread's own stream parent wins over the shell parent
- **xeus-python guard** (passes): mirrors the surface of a real xeus-python kernel (no shell `get_parent`/`set_parent`; `kernel.get_parent()` returns a full request) — capture works via the kernel fallback alone, so non-ipykernel kernels are unaffected (re-verified live against xeus-python 0.19.0 with the fix)

### Real-kernel tests (`test_widget_output_parent_kernel.py`)

Starts an actual ipykernel via `jupyter_client` and asserts on the parent attribution of the iopub messages the kernel really publishes — the automated equivalent of the notebooks above, using the same `threading.Event` chaining (~2s wall clock, no sleeps). Skips when `jupyter_client`/`ipykernel` are unavailable; CI installs ipykernel via the `[test]` extra. All four tests pass on ipykernel 6.29.5, 7.3.0, and the ipython/ipykernel#1546 branch:

- unrelated thread's output is not attributed to the captured cell
- the capturing thread's output lands in the widget — and is attributed to the thread's own cell on ipykernel 6 (ancestry), or the cell current at re-entry on ipykernel 7 (transient)
- the parent override does not outlive the block
- a foreign cell's parent is not pinned across blocks

https://claude.ai/code/session_0136XmUCLSRfgHrrVw1QYMiW