### PR TITLE
Add github-actions ecosystem to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,4 +17,4 @@ updates:
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'semiannually'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,7 @@ updates:
     open-pull-requests-limit: 0 # in case you don't want to enable version updates
     allow:
       - dependency-type: 'production'
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
> [!NOTE]
> This pull request was generated by [Claude Code](https://claude.ai/code) at Jason's request.

Item 6 of #11: `.github/dependabot.yml` currently watches only npm production dependencies (security updates only). This adds a `github-actions` ecosystem entry on a weekly schedule so action versions are kept current automatically instead of by manual sweep.

The npm entry is unchanged. No `pip` entry is added for now — that would generate version-update PRs for the docs/test requirements, which seemed worth a separate decision.

Part of the #11 breakdown; independent of #9 and #10 (no shared files).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fmi26Cmebe6shFPWbexj4e)_