### PR TITLE
Rename nose-style teardown to teardown_method in test_embed

### DIFF
--- a/python/ipywidgets/ipywidgets/tests/test_embed.py
+++ b/python/ipywidgets/ipywidgets/tests/test_embed.py
@@ -28,7 +28,7 @@ class CaseWidget(Widget):
 
 class TestEmbed:
 
-    def teardown(self):
+    def teardown_method(self):
         for w in tuple(widget_module._instances.values()):
             w.close()
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was generated by [Claude Code](https://claude.ai/code) at Jason's request.

This is the root cause behind CI's `pip install "pytest<8"` pin. The pin was added in upstream commit `7265b2fe` (Feb 2024, "ci: pytest 8 warns for deprecation warning of nose", jupyter-widgets/ipywidgets#3883): pytest 7.2 deprecated nose-style `setup`/`teardown` methods and the warning failed the build, since warnings are treated as failures.

`TestEmbed.teardown` in `ipywidgets/tests/test_embed.py` is the one nose-style hook in the suite (the `setup` in `widgets/tests/utils.py` is already a proper pytest fixture). On pytest 8+, nose support is *removed*, so the old name is silently never called — tests happen to still pass, but the per-test widget cleanup (`w.close()` on all instances) stops running. Renaming to the native xunit-style `teardown_method` restores identical behavior on every pytest version, old and new.

Verified: full suite (310 tests) passes on pytest 9.1.1 with `-W error::DeprecationWarning`.

This unblocks dropping the `pytest<8` pin from `tests.yml` — that one-line CI change can't be pushed from this session (its credentials lack the `workflow` OAuth scope), so it's delivered separately as a patch. Merge this PR first, then apply the pin removal.

Part of the #11 breakdown (item 8); independent of #9 and #10.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fmi26Cmebe6shFPWbexj4e)_